### PR TITLE
fix: check_and_call_extract_file uses the first matching method and options

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -276,6 +276,7 @@ def check_and_call_extract_file(
         for opattern, odict in options_map.items():
             if pathmatch(opattern, filename):
                 options = odict
+                break
         if callback:
             callback(filename, method, options)
         for message_tuple in extract_from_file(


### PR DESCRIPTION
... instead of the first matching method and **last** matching options.

Otherwise, if I want to use a different method for one file AND use options, I can't do, for example:

```ini
[myextractor: path/file.py]
myoption = myvalue

[python: path/**.py]
```

The current code will match `path/file.py` to `myextractor`, but it'll use the empty options from `python`...